### PR TITLE
aircrack-ng: backport patch to fix gpsd option for airodump-ng

### DIFF
--- a/net/aircrack-ng/patches/106-backport-gpsd-fix-airodump.patch
+++ b/net/aircrack-ng/patches/106-backport-gpsd-fix-airodump.patch
@@ -1,0 +1,12 @@
+diff -dur aircrack-ng-1.7/src/airodump-ng/airodump-ng.c aircrack-ng-1.7-bugfix/src/airodump-ng/airodump-ng.c
+--- a/src/airodump-ng/airodump-ng.c	2022-05-10 19:01:46.000000000 -0400
++++ b/src/airodump-ng/airodump-ng.c	2024-04-03 17:37:35.496429825 -0400
+@@ -4429,7 +4429,7 @@
+ 	char * vcursor = value;
+ 	int ret = 0;
+ 
+-	if (buffer == NULL || *buffer == '\0' || name == NULL || *name != '\0'
++	if (buffer == NULL || *buffer == '\0' || name == NULL || *name == '\0'
+ 		|| value == NULL)
+ 	{
+ 		return (0);


### PR DESCRIPTION
`airodump-ng --gpsd` does not work in airodump 1.7 release.

It's fixed in the current rolling version, but there's been no new release in nearly two years and no sign of a new release being imminent.

So, this is a backported patch to fix the OpenWrt version; it's a direct copy of the official patch at https://github.com/aircrack-ng/aircrack-ng/commit/6d4539c1cefc12ce4c37f3a5e2ef694152894393

Maintainer: Rick Farina <zerochaos@gentoo.org> (listed in Makefile) @Ansuel (last commit)
Compile tested: Compiled for GL.iNet E750 running OpenWrt 23.05.2, MIPS Big-Endian
Run tested: Tested working on OpenWrt 23.05.2, MIPS Big-Endian

Description: Fixes a bug where trying to use GPS with `airodump-ng` gets no GPS data, and also causes `airodump-ng` to hang and ignore ctrl-c.